### PR TITLE
Updating small portions of code to work with pytorch 1.5.0

### DIFF
--- a/cifar10_data.py
+++ b/cifar10_data.py
@@ -25,7 +25,7 @@ class CIFAR10RandomLabels(datasets.CIFAR10):
       self.corrupt_labels(corrupt_prob)
 
   def corrupt_labels(self, corrupt_prob):
-    labels = np.array(self.train_labels if self.train else self.test_labels)
+    labels = np.array(self.targets)
     np.random.seed(12345)
     mask = np.random.rand(len(labels)) <= corrupt_prob
     rnd_labels = np.random.choice(self.n_classes, mask.sum())
@@ -34,8 +34,5 @@ class CIFAR10RandomLabels(datasets.CIFAR10):
     # builtin int type, otherwise pytorch will fail...
     labels = [int(x) for x in labels]
 
-    if self.train:
-      self.train_labels = labels
-    else:
-      self.test_labels = labels
+    self.targets = labels
 

--- a/train.py
+++ b/train.py
@@ -125,8 +125,8 @@ def train_epoch(train_loader, model, criterion, optimizer, epoch, args):
 
     # measure accuracy and record loss
     prec1 = accuracy(output.data, target, topk=(1,))[0]
-    losses.update(loss.data[0], input.size(0))
-    top1.update(prec1[0], input.size(0))
+    losses.update(loss.item(), input.size(0))
+    top1.update(prec1.item(), input.size(0))
 
     # compute gradient and do SGD step
     optimizer.zero_grad()
@@ -157,8 +157,8 @@ def validate_epoch(val_loader, model, criterion, epoch, args):
 
     # measure accuracy and record loss
     prec1 = accuracy(output.data, target, topk=(1,))[0]
-    losses.update(loss.data[0], input.size(0))
-    top1.update(prec1[0], input.size(0))
+    losses.update(loss.item(), input.size(0))
+    top1.update(prec1.item(), input.size(0))
 
   return losses.avg, top1.avg
 


### PR DESCRIPTION
Code does not work out of the box anymore, since pytorch has been upgraded. Added the necessary changes, and tested with:

```
python train.py --arch=mlp --mlp-spec=512 --label-corrupt-prob=1.0 --learning-rate=0.01
```
and gets very similar values as the ones on the README.